### PR TITLE
runtime env config

### DIFF
--- a/docs/modules/installation/pages/runtime_env_configuration.adoc
+++ b/docs/modules/installation/pages/runtime_env_configuration.adoc
@@ -3,14 +3,14 @@
 HTTP port and context path can be easily configured in *Axion*.
 
 == HTTP Port
-The default value for the HTTP port used to access the *Axion* user interface and resources is 8080. Therefore the user interface would be available at _http://localhost:8080/_. To change or update the port, locate the line  _port: 8080_ in _src/main/properties.yml_ , then edit the number. For example, lets set the port value to _8081_:
+The default value for the HTTP port used to access the *Axion* user interface and resources is 8080. Therefore the user interface would be available at _http://localhost:8080/_. To change or update the port, locate the line  _port: 8080_ in _src/main/application.yml_ , then edit the number. For example, lets set the port value to _8081_:
 ....
 port: 8081
 ....
 The URL will be _http://localhost:8081/_.
 
 == Changing the Context Path
-To change or update the context path in the instance you want point to a specific webapp or component, locate the _context-path: /_ line in the _src/main/properties.yml_. Example for directory named _radar_:
+To change or update the context path in the instance you want point to a specific webapp or component, locate the _context-path: /_ line in the _src/main/application.yml_. Example for directory named _radar_:
 ....
 context-path: /radar/
 ....

--- a/docs/modules/installation/pages/runtime_env_configuration.adoc
+++ b/docs/modules/installation/pages/runtime_env_configuration.adoc
@@ -10,8 +10,8 @@ port: 8081
 The URL will be _http://localhost:8081/_.
 
 == Changing the Context Path
-To change or update the context path in the instance you want point to a specific webapp or component, locate the _context-path: /_ line in the _src/main/application.yml_. Example for directory named _radar_:
+To change or update the context path in the instance you want point to a specific webapp or component, locate the _context-path: /_ line in the _src/main/application.yml_. Example for directory named _axion_:
 ....
-context-path: /radar/
+context-path: /axion/
 ....
-The URL will be _http://localhost:8081/radar/_.
+The URL will be _http://localhost:8081/axion/_.

--- a/docs/modules/installation/pages/runtime_env_configuration.adoc
+++ b/docs/modules/installation/pages/runtime_env_configuration.adoc
@@ -1,3 +1,17 @@
-= Runtime env configuration
+= Runtime environment configuration
 
-Could you review https://help.sonatype.com/repomanager3/installation-and-upgrades/configuring-the-runtime-environment sections "Changing the HTTP Port" & "Changing the Context Path"
+HTTP port and context path can be easily configured in *Axion*.
+
+== HTTP Port
+The default value for the HTTP port used to access the *Axion* user interface and resources is 8080. Therefore the user interface would be available at _http://localhost:8080/_. To change or update the port, locate the line  _port: 8080_ in _src/main/properties.yml_ , then edit the number. For example, lets set the port value to _8081_:
+....
+port: 8081
+....
+The URL will be _http://localhost:8081/_.
+
+== Changing the Context Path
+To change or update the context path in the instance you want point to a specific webapp or component, locate the _context-path: /_ line in the _src/main/properties.yml_. Example for directory named _radar_:
+....
+context-path: /radar/
+....
+The URL will be _http://localhost:8081/radar/_.


### PR DESCRIPTION
@arufanov we can only change env when building from source? didn't fined any configs when launching a *.jar...

or did you mean to start with env configs – ExecStart=java -jar {{ app__current_path }}/target/axion-0.1.0-SNAPSHOT.jar --application.keys.google_analytics={{ app__google_analytics }} --?